### PR TITLE
pyg4ometry glue for LAr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v4.3.0"
+  rev: "v4.4.0"
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -24,41 +24,41 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/asottile/setup-cfg-fmt
-  rev: "v2.0.0"
+  rev: "v2.2.0"
   hooks:
   - id: setup-cfg-fmt
 
 - repo: https://github.com/PyCQA/isort
-  rev: "5.10.1"
+  rev: "5.12.0"
   hooks:
   - id: isort
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: "v2.38.0"
+  rev: "v3.3.1"
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
 
 - repo: https://github.com/psf/black
-  rev: "22.8.0"
+  rev: "23.3.0"
   hooks:
   - id: black
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.971"
+  rev: "v1.1.1"
   hooks:
     - id: mypy
       files: src
       stages: [manual]
 
 - repo: https://github.com/hadialqattan/pycln
-  rev: "v2.1.1"
+  rev: "v2.1.3"
   hooks:
   - id: pycln
     args: ["--all"]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: "5.0.4"
+  rev: "6.0.0"
   hooks:
   - id: flake8
     additional_dependencies: [
@@ -70,31 +70,31 @@ repos:
     args: ["--docstring-convention", "numpy"]  # or google, change me
 
 - repo: https://github.com/kynan/nbstripout
-  rev: "0.6.0"
+  rev: "0.6.1"
   hooks:
     - id: nbstripout
       args: ["--strip-empty-cells",
              "--extra-keys", "metadata.kernelspec metadata.language_info"]
 
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.48"
+  rev: "0.49"
   hooks:
   - id: check-manifest
     stages: [manual]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.2.1"
+  rev: "v2.2.4"
   hooks:
   - id: codespell
     args: ["-L", "nd,unparseable,compiletime"]
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: "v0.8.0.4"
+  rev: "v0.9.0.2"
   hooks:
   - id: shellcheck
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: "v1.9.0"
+  rev: "v1.10.0"
   hooks:
   - id: python-no-log-warn
   - id: rst-backticks
@@ -102,7 +102,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v3.0.0-alpha.0"
+  rev: "v3.0.0-alpha.6"
   hooks:
     - id: prettier
       types_or: [json]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     numpy
     pint
     scipy
+    pyg4ometry
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = legend-pygeom-optics
+name = legend_pygeom_optics
 version = attr: legendoptics._version.version
 description = Optical properties of the LEGEND experiment
 long_description = file: README.md
@@ -34,8 +34,8 @@ install_requires =
     matplotlib
     numpy
     pint
-    scipy
     pyg4ometry
+    scipy
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/src/legendoptics/copper.py
+++ b/src/legendoptics/copper.py
@@ -1,13 +1,10 @@
-"""
-Copper
-"""
-    
+"""Copper."""
+
 from __future__ import annotations
 
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/fibers.py
+++ b/src/legendoptics/fibers.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import InterpolatingGraph, readdatafile
@@ -85,8 +84,9 @@ def fiber_absorption_length() -> float:
 
 
 def fiber_absorption_path_length() -> float:
-    """Absorption length of fiber [SaintGobainDataSheet]_, multiplied by an empirical factor to account for
-    the prolonged path length inside a square fiber with 1mm side length.
+    """Absorption length of fiber [SaintGobainDataSheet]_, corrected for the geometry of a 1 mm square fiber.
+
+    Multiplied by an empirical factor to account for the prolonged path length inside a square fiber with 1mm side length.
 
     See Also
     --------

--- a/src/legendoptics/germanium.py
+++ b/src/legendoptics/germanium.py
@@ -1,5 +1,4 @@
-"""
-Germanium 
+"""Germanium.
 
 .. [Wegmann2017] A. Wegmann “Characterization of the liquid argon veto of the GERDA
     experiment and its application for the measurement of the 76Ge half-life”
@@ -11,7 +10,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -21,8 +21,6 @@
 .. [Hitachi1983] A. Hitachi et al. “Effect of ionization density on the time dependence of luminescence
     from liquid argon and xenon.” In: Phys. Rev. B 27 (9 May 1983), pp. 5279–5285,
     https://doi.org/10.1103/PhysRevB.27.5279
-.. [Pertoldi2020] L. Pertoldi “Search for new physics with two-neutrino double-beta decay in
-    GERDA data.” 2020, https://www.mpi-hd.mpg.de/gerda/public/2020/phd2020_LuigiPertoldi.pdf
 """
 from __future__ import annotations
 
@@ -190,42 +188,69 @@ def lar_abs_length(λ: Quantity) -> Quantity:
     return np.minimum(absl, 100000 * u.cm)  # avoid large numbers
 
 
-def lar_peak_attenuation_length() -> Quantity:
+def lar_peak_attenuation_length(
+    attenuation_method: str | Quantity = "legend200-llama",
+) -> Quantity:
     """Attenuation length in the LEGEND-argon, as measured with LLAMA."""
-    return 30 * u.cm
+    if isinstance(attenuation_method, str):
+        if attenuation_method == "legend200-llama":
+            return 30 * u.cm
+        else:
+            raise ValueError(f"unknown attenuation_method {attenuation_method}")
+    else:
+        assert attenuation_method.check("[length]")
+        return attenuation_method
 
 
-def lar_lifetimes() -> ArScintLiftime:
+def lar_lifetimes(
+    triplet_lifetime_method: float | str = "legend200-llama",
+) -> ArScintLiftime:
     """Singlet and triplet lifetimes of liquid argon.
 
-    Singlet time from [Hitachi1983]_ and triplet time as measured in GERDA phase II
-    ([Pertoldi2020]_, fig. 2.10).
+    Singlet time from [Hitachi1983]_ and triplet time as measured by LLAMA in LEGEND-200.
     """
-    return ArScintLiftime(singlet=5.95 * u.ns, triplet=1 * u.us)
+    triplet = 1 * u.us
+    if isinstance(triplet_lifetime_method, str):
+        if triplet_lifetime_method == "legend200-llama":
+            triplet = 1.3 * u.us
+        else:
+            raise ValueError(
+                f"unknown triplet_lifetime_method {triplet_lifetime_method}"
+            )
+    else:
+        triplet = triplet_lifetime_method * u.us
+
+    return ArScintLiftime(singlet=5.95 * u.ns, triplet=triplet)
 
 
-def lar_scintillation_params() -> ScintConfig:
+def lar_scintillation_params(flat_top_yield: Quantity = 31250 / u.MeV) -> ScintConfig:
     """Scintillation yield (approx. inverse of the mean energy to produce a UV photon).
 
     This depends on the nature of the impinging particles, the field configuration
-    and the quencher impurities. We set here just a reference value from [Doke2002]_,
-    that probably does not represent the reality of GERDA/LEGEND:
+    and the quencher impurities. We set here just a reference value that is lower than
+    the value provided by [Doke2002]_, that probably does not represent experimental
+    reality.
 
-    for flat top response particles the mean energy to produce a photon is 19.5 eV
-    => Y = 1/19.5 = 0.051
+    For flat-top response particles the mean energy to produce a photon is 19.5 eV
+    .. math::
+        Y = 1/(19.5 eV) = 0.051 eV^{-1}
 
     At zero electric field, for not-flat-top particles, the scintillation yield,
     relative to the one of flat top particles is:
-    Y_e = 0.8 Y
-    Y_alpha = 0.7 Y
-    Y_recoils = 0.2-0.4
+    .. math::
+
+        Y_e = 0.8 Y
+
+        Y_alpha = 0.7 Y
+
+        Y_recoils = 0.2-0.4
 
     Excitation ratio:
     For example, for nuclear recoils it should be 0.75
     nominal value for electrons and gammas: 0.23 (WArP data)
     """
     return ScintConfig(
-        flat_top=31250 / u.MeV,
+        flat_top=flat_top_yield,
         particles=[
             ScintParticle("electron", yield_factor=0.8, exc_ratio=0.23),
             ScintParticle("alpha", yield_factor=0.7, exc_ratio=1),
@@ -234,27 +259,142 @@ def lar_scintillation_params() -> ScintConfig:
     )
 
 
-def pyg4_lar_define_opticalproperties(
-    lar_mat, lar_temperature: Quantity, reg, lar_dielectric_method="cern2020"
+def pyg4_lar_attach_rindex(
+    lar_mat, reg, lar_dielectric_method: str = "cern2020"
 ) -> None:
-    """Define all liquid argon optical properties on a geant4 material, as defined by this module."""
-    from legendoptics.pyg4utils import pyg4_def_scint_by_particle_type, pyg4_sample_λ
+    """Attach the refractive index to the given LAr material instance.
+
+    Parameters
+    ----------
+    lar_dielectric_method
+        Choose which calculation method is used for calculation of the refractive
+        index.
+
+    See Also
+    --------
+    .lar_refractive_index
+    .lar_dielectric_constant
+    """
+    from legendoptics.pyg4utils import pyg4_sample_λ
 
     λ_full = pyg4_sample_λ(112 * u.nm, 650 * u.nm)
-    λ_peak = pyg4_sample_λ(116 * u.nm, 141 * u.nm)
-
-    # build arrays with properties
     rindex = lar_refractive_index(λ_full, lar_dielectric_method)
+    with u.context("sp"):
+        lar_mat.addVecPropertyPint("RINDEX", λ_full.to("eV"), rindex)
+
+
+def pyg4_lar_attach_attenuation(
+    lar_mat,
+    reg,
+    lar_temperature: Quantity,
+    lar_dielectric_method: str = "cern2020",
+    attenuation_method_or_length: str | Quantity = "legend200-llama",
+    rayleigh_enabled_or_length: bool | Quantity = True,
+    absorption_enabled_or_length: bool | Quantity = True,
+) -> None:
+    """Define all liquid argon optical properties on a Geant4 material, as defined by this module.
+
+    Parameters
+    ----------
+    lar_temperature
+        liquid phase temperature for rayleigh scattering length calculation.
+    lar_dielectric_method
+        Choose which calculation method is used for calculation of the dielectric
+        function, which is used for deriving the rayleigh scattering length.
+    attenuation_method_or_length
+        Change the method/measurement used to define the LAr triplet state lifetime.
+        If set to a length-Quantity, this value is used directly as attenuation length at
+        the scintillation peak.
+    rayleigh_enabled_or_length
+        If set to a boolean value, it enables or disables the default rayleigh scattering.
+
+        If set to a length-Quantity, the given value will be used as the scattering length at
+        the scintillation peak.
+    absorption_enabled_or_length
+        If set to a boolean value, the default absorption length is used (i.e. it is derived
+        from the scattering length and the total attenuation length).
+
+        If set to a length-Quantity, the given value will be used as the absorption length at
+        the scintillation peak.
+
+    Notes
+    -----
+    If all three of rayleigh length, absorption length and attenuation length are set via the function
+    parameters, the parameter on total attenuation length will be ignored!
+
+    See Also
+    --------
+    .lar_rayleigh
+    .lar_peak_attenuation_length
+    .lar_abs_length
+    """
+    from legendoptics.pyg4utils import pyg4_sample_λ
+
+    if (
+        isinstance(absorption_enabled_or_length, Quantity)
+        and isinstance(rayleigh_enabled_or_length, Quantity)
+        and isinstance(attenuation_method_or_length, Quantity)
+    ):
+        log.warning(
+            "All three of attenuation, absorption and rayleigh scattering length are constrained manually. The specified attenuation length will be ignored."
+        )
+
+    λ_full = pyg4_sample_λ(112 * u.nm, 650 * u.nm)
+
+    # rayleigh scattern is a (theoretically) defined property.
     rayleigh = lar_rayleigh(λ_full, lar_temperature, lar_dielectric_method)
-
-    #
     peak_rayleigh_length = lar_rayleigh(126.8 * u.nm, lar_temperature)
+    if isinstance(rayleigh_enabled_or_length, Quantity):
+        assert rayleigh_enabled_or_length.check("[length]")
+        peak_abs_length = rayleigh_enabled_or_length
 
-    # absorption length and rayleigh add up inversely to the attenuation length.
-    peak_abs_length = 1 / (1 / lar_peak_attenuation_length() - 1 / peak_rayleigh_length)
+    # absorption length and rayleigh add up inversely to the measured attenuation length.
+    peak_att_length = lar_peak_attenuation_length(attenuation_method_or_length)
+
+    peak_abs_length = 1 / (1 / peak_att_length - 1 / peak_rayleigh_length)
+    if isinstance(absorption_enabled_or_length, Quantity):
+        assert absorption_enabled_or_length.check("[length]")
+        peak_abs_length = absorption_enabled_or_length
+
     absl_scale = peak_abs_length / lar_abs_length(126.8 * u.nm)
     abslength = lar_abs_length(λ_full) * absl_scale
 
+    with u.context("sp"):
+        if rayleigh_enabled_or_length is not False:
+            lar_mat.addVecPropertyPint("RAYLEIGH", λ_full.to("eV"), rayleigh)
+        if absorption_enabled_or_length is not False:
+            lar_mat.addVecPropertyPint("ABSLENGTH", λ_full.to("eV"), abslength)
+
+
+def pyg4_lar_attach_scintillation(
+    lar_mat,
+    reg,
+    flat_top_yield: Quantity = 31250 / u.MeV,
+    triplet_lifetime_method: float | str = "legend200-llama",
+) -> None:
+    """Attach Geant4 properties for LAr scintillation response to the given Geant4 material.
+
+    Parameters
+    ----------
+    flat_top_yield_per_mev
+        Change the flat-top light yield of the scintillation response. Note that for
+        different particle types, the value might be lower(see .lar_scintillation_params).
+    triplet_lifetime_method
+        Change the method/measurement used to define the LAr triplet state lifetime.
+        If set to a number, this value is used directly as lifetime in µs.
+
+    See Also
+    --------
+    .lar_scintillation_params
+    .lar_fano_factor
+    .lar_emission_spectrum
+    .lar_lifetimes
+    """
+    from legendoptics.pyg4utils import pyg4_def_scint_by_particle_type, pyg4_sample_λ
+
+    λ_peak = pyg4_sample_λ(116 * u.nm, 141 * u.nm)
+
+    # sample the measured emission spectrum.
     scint_em = InterpolatingGraph(
         *lar_emission_spectrum(),
         min_idx=115 * u.nm,
@@ -264,19 +404,15 @@ def pyg4_lar_define_opticalproperties(
     scint_em[0] = 0
     scint_em[-1] = 0
 
-    lar_mat.addConstProperty("RESOLUTIONSCALE", lar_fano_factor())
-
     with u.context("sp"):
-        lar_mat.addVecProperty("RINDEX", λ_full.to("eV"), rindex)
-        lar_mat.addVecProperty("RAYLEIGH", λ_full.to("eV"), rayleigh)
-        lar_mat.addVecProperty("ABSLENGTH", λ_full.to("eV"), abslength)
-
-        lar_scint = lar_mat.addVecProperty(
+        lar_scint = lar_mat.addVecPropertyPint(
             "SCINTILLATIONCOMPONENT1", λ_peak.to("eV"), scint_em
         )
         lar_mat.addProperty("SCINTILLATIONCOMPONENT2", lar_scint)
 
-    lar_mat.addConstProperty("SCINTILLATIONTIMECONSTANT1", lar_lifetimes().singlet)
-    lar_mat.addConstProperty("SCINTILLATIONTIMECONSTANT2", lar_lifetimes().triplet)
+    lifetimes = lar_lifetimes(triplet_lifetime_method)
+    lar_mat.addConstPropertyPint("SCINTILLATIONTIMECONSTANT1", lifetimes.singlet)
+    lar_mat.addConstPropertyPint("SCINTILLATIONTIMECONSTANT2", lifetimes.triplet)
+    lar_mat.addConstPropertyPint("RESOLUTIONSCALE", lar_fano_factor())
 
-    pyg4_def_scint_by_particle_type(lar_mat, lar_scintillation_params())
+    pyg4_def_scint_by_particle_type(lar_mat, lar_scintillation_params(flat_top_yield))

--- a/src/legendoptics/nylon.py
+++ b/src/legendoptics/nylon.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/plot.py
+++ b/src/legendoptics/plot.py
@@ -2,15 +2,12 @@ from typing import Callable
 
 import matplotlib.pyplot as plt
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 pint.get_application_registry().setup_matplotlib(True)
 
 
-def plot_continuous_prop(
-    ax: plt.Axes, prop: Callable, x: Quantity, param_dict=None
-):
+def plot_continuous_prop(ax: plt.Axes, prop: Callable, x: Quantity, param_dict=None):
     """Plot continuous property.
 
     Plots the `prop` function on values `x` with matplotlib's :func:`plot`.

--- a/src/legendoptics/pyg4utils.py
+++ b/src/legendoptics/pyg4utils.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import numpy as np
+import pint
+import logging
+import scipy.interpolate
+from importlib_resources import files
+from numpy.typing import NDArray
+from pint import Quantity
+
+import pyg4ometry
+import pyg4ometry.geant4 as g4
+
+from .utils import ScintConfig
+
+log = logging.getLogger(__name__)
+ureg = pint.get_application_registry().get()
+
+
+NUMENTRIES = 69
+NUMENTRIES_2 = 200 #500
+
+
+@ureg.with_context('sp')
+def pyg4_sample_λ(
+    start_lambda: Quantity,
+    end_lambda: Quantity,
+    sample_count: int = NUMENTRIES_2
+) -> Quantity:
+    """Sample equally-spaced energies between the two specified wavelengths, and again return the energies
+    converted to wavelengths."""
+    assert(start_lambda <= end_lambda)
+
+    samples = np.linspace(end_lambda.to('eV'), start_lambda.to('eV'), num=sample_count)
+    return samples.to('nm')
+
+
+def _get_scint_yield_vector(yield_per_mev: Quantity):
+    """In Geant4 11.0, ScintillationByParticleType takes some sort of integrated scintiallation yield:
+
+    ScintillationYield = yieldVector->Value(PreStepKineticEnergy)
+            - yieldVector->Value(PreStepKineticEnergy - StepEnergyDeposit);
+
+    and ScintillationYield is directly used as MeanNumberOfPhotons. To fulfill this we use a simple
+    linear function.
+    """
+    ye = ureg.Quantity(np.array([1, 10e6]), ureg.eV)
+    yv = [f'{(10*ureg.eV*yield_per_mev).to_reduced_units():~}', f'{(10*ureg.MeV*yield_per_mev).to_reduced_units():~}']
+    return ye, yv
+
+
+def _def_scint_particle(mat, particle: str, y: Quantity, yield_factor: float, exc_ratio: float) -> None:
+    """Defines a single particle type used by Geant4's ScintillationByParticleType."""
+    mat.addVecProperty(particle + 'SCINTILLATIONYIELD', *_get_scint_yield_vector(y * yield_factor))
+    mat.addConstProperty(particle + 'SCINTILLATIONYIELD1', exc_ratio)
+    mat.addConstProperty(particle + 'SCINTILLATIONYIELD2', 1 - exc_ratio)
+
+
+def pyg4_def_scint_by_particle_type(mat, scint_cfg: ScintConfig) -> None:
+    """Defines a full set of particles for scintillation."""
+    for particle in scint_cfg.particles:
+        _def_scint_particle(mat, particle.name.upper(), scint_cfg.flat_top, particle.yield_factor, particle.exc_ratio)
+
+
+@pint.register_unit_format("gdml")
+def _gdml_format(unit, registry, **options):
+    proc = { u.replace("µ", "u"): e for u,e in unit.items() }
+    return pint.formatter(
+        proc.items(),
+        as_ratio=True,
+        single_denominator=False,
+        product_fmt="*",
+        division_fmt="/",
+        power_fmt="{}{}", #TODO: validate only validate power units (e.g. mm2) get through.
+        parentheses_fmt="({})",
+        **options,
+    )
+
+
+def _patch_g4_pint_unit_support() -> None:
+    """code::`pyg4ometry` does currently not support code::`pint` unit that we use extensively here.
+
+    This function overrides some helper functions to make adding material properties nicer.
+    The overridden functions also check for some common properties to be used with the correct units.
+    """
+    def _val_pint_to_gdml(v):
+        if not isinstance(v, pint.Quantity):
+            return '', v
+
+        base_unit = v.units
+
+        unit = f"{base_unit:~gdml}"
+        assert(unit==f"{base_unit:~}".replace(" ", "").replace("µ", "u"))
+        log.debug(f"Unit pint->gdml: {unit} - {base_unit}")
+
+        v = v.m_as(base_unit)
+        return unit, v
+
+    orig_addVecProperty = g4.WithPropertiesBase.addVecProperty
+    def addVecProperty(self, name, e, v):
+        vunit, v = _val_pint_to_gdml(v)
+        eunit, e = _val_pint_to_gdml(e)
+
+        if name in ["ABSLENGTH", "WLSABSLENGTH", "RAYLEIGH"] and vunit not in ["m", "cm", "mm", "um"]:
+            log.warn("Wrong unit %s for property %s", vunit, name)
+        if name in ["RINDEX", "WLSCOMPONENT", "REFLECTIVITY"] and vunit != "":
+            log.warn("Wrong unit %s for property %s", vunit, name)
+        if eunit not in ["", "eV", "keV", "MeV", "GeV", "TeV" "PeV"]:
+            log.warn("Wrong energy unit %s", eunit)
+
+        return orig_addVecProperty(self, name, e, v, eunit, vunit)
+    g4.WithPropertiesBase.addVecProperty = addVecProperty
+
+    orig_addConstProperty = g4.WithPropertiesBase.addConstProperty
+    def addConstProperty(self, name, value):
+        vunit, value = _val_pint_to_gdml(value)
+
+        if name in ["SCINTILLATIONYIELD"]:
+            log.warn("%s cannot be used with scintillationByParticleType", name)
+
+        return orig_addConstProperty(self, name, value, vunit)
+    g4.WithPropertiesBase.addConstProperty = addConstProperty
+
+_patch_g4_pint_unit_support()
+
+
+__all__ = ['pyg4_sample_λ', 'pyg4_def_scint_by_particle_type']

--- a/src/legendoptics/pyg4utils.py
+++ b/src/legendoptics/pyg4utils.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pint
-import logging
-import scipy.interpolate
-from importlib_resources import files
-from numpy.typing import NDArray
-from pint import Quantity
-
-import pyg4ometry
 import pyg4ometry.geant4 as g4
+from pint import Quantity
 
 from .utils import ScintConfig
 
@@ -18,25 +14,22 @@ ureg = pint.get_application_registry().get()
 
 
 NUMENTRIES = 69
-NUMENTRIES_2 = 200 #500
+NUMENTRIES_2 = 200  # 500
 
 
-@ureg.with_context('sp')
+@ureg.with_context("sp")
 def pyg4_sample_λ(
-    start_lambda: Quantity,
-    end_lambda: Quantity,
-    sample_count: int = NUMENTRIES_2
+    start_lambda: Quantity, end_lambda: Quantity, sample_count: int = NUMENTRIES_2
 ) -> Quantity:
-    """Sample equally-spaced energies between the two specified wavelengths, and again return the energies
-    converted to wavelengths."""
-    assert(start_lambda <= end_lambda)
+    """Sample equally-spaced energies between the two specified wavelengths."""
+    assert start_lambda <= end_lambda
 
-    samples = np.linspace(end_lambda.to('eV'), start_lambda.to('eV'), num=sample_count)
-    return samples.to('nm')
+    samples = np.linspace(end_lambda.to("eV"), start_lambda.to("eV"), num=sample_count)
+    return samples.to("nm")
 
 
 def _get_scint_yield_vector(yield_per_mev: Quantity):
-    """In Geant4 11.0, ScintillationByParticleType takes some sort of integrated scintiallation yield:
+    """In Geant4 11.0, ScintillationByParticleType takes some sort of integrated scintillation yield.
 
     ScintillationYield = yieldVector->Value(PreStepKineticEnergy)
             - yieldVector->Value(PreStepKineticEnergy - StepEnergyDeposit);
@@ -45,33 +38,43 @@ def _get_scint_yield_vector(yield_per_mev: Quantity):
     linear function.
     """
     ye = ureg.Quantity(np.array([1, 10e6]), ureg.eV)
-    yv = [f'{(10*ureg.eV*yield_per_mev).to_reduced_units():~}', f'{(10*ureg.MeV*yield_per_mev).to_reduced_units():~}']
+    yv = [f"{(e*yield_per_mev).to_reduced_units():~}" for e in ye]
     return ye, yv
 
 
-def _def_scint_particle(mat, particle: str, y: Quantity, yield_factor: float, exc_ratio: float) -> None:
-    """Defines a single particle type used by Geant4's ScintillationByParticleType."""
-    mat.addVecProperty(particle + 'SCINTILLATIONYIELD', *_get_scint_yield_vector(y * yield_factor))
-    mat.addConstProperty(particle + 'SCINTILLATIONYIELD1', exc_ratio)
-    mat.addConstProperty(particle + 'SCINTILLATIONYIELD2', 1 - exc_ratio)
+def _def_scint_particle(
+    mat, particle: str, y: Quantity, yield_factor: float, exc_ratio: float
+) -> None:
+    """Define a single particle type used by Geant4's ScintillationByParticleType."""
+    mat.addVecProperty(
+        particle + "SCINTILLATIONYIELD", *_get_scint_yield_vector(y * yield_factor)
+    )
+    mat.addConstProperty(particle + "SCINTILLATIONYIELD1", exc_ratio)
+    mat.addConstProperty(particle + "SCINTILLATIONYIELD2", 1 - exc_ratio)
 
 
 def pyg4_def_scint_by_particle_type(mat, scint_cfg: ScintConfig) -> None:
-    """Defines a full set of particles for scintillation."""
+    """Define a full set of particles for scintillation."""
     for particle in scint_cfg.particles:
-        _def_scint_particle(mat, particle.name.upper(), scint_cfg.flat_top, particle.yield_factor, particle.exc_ratio)
+        _def_scint_particle(
+            mat,
+            particle.name.upper(),
+            scint_cfg.flat_top,
+            particle.yield_factor,
+            particle.exc_ratio,
+        )
 
 
 @pint.register_unit_format("gdml")
 def _gdml_format(unit, registry, **options):
-    proc = { u.replace("µ", "u"): e for u,e in unit.items() }
+    proc = {u.replace("µ", "u"): e for u, e in unit.items()}
     return pint.formatter(
         proc.items(),
         as_ratio=True,
         single_denominator=False,
         product_fmt="*",
         division_fmt="/",
-        power_fmt="{}{}", #TODO: validate only validate power units (e.g. mm2) get through.
+        power_fmt="{}{}",  # TODO: validate only validate power units (e.g. mm2) get through.
         parentheses_fmt="({})",
         **options,
     )
@@ -83,45 +86,52 @@ def _patch_g4_pint_unit_support() -> None:
     This function overrides some helper functions to make adding material properties nicer.
     The overridden functions also check for some common properties to be used with the correct units.
     """
+
     def _val_pint_to_gdml(v):
         if not isinstance(v, pint.Quantity):
-            return '', v
+            return "", v
 
         base_unit = v.units
 
         unit = f"{base_unit:~gdml}"
-        assert(unit==f"{base_unit:~}".replace(" ", "").replace("µ", "u"))
+        assert unit == f"{base_unit:~}".replace(" ", "").replace("µ", "u")
         log.debug(f"Unit pint->gdml: {unit} - {base_unit}")
 
         v = v.m_as(base_unit)
         return unit, v
 
-    orig_addVecProperty = g4.WithPropertiesBase.addVecProperty
-    def addVecProperty(self, name, e, v):
+    orig_addVecProperty = g4.WithPropertiesBase.addVecProperty  # noqa: N806
+
+    def addVecProperty(self, name, e, v):  # noqa: N802
         vunit, v = _val_pint_to_gdml(v)
         eunit, e = _val_pint_to_gdml(e)
 
-        if name in ["ABSLENGTH", "WLSABSLENGTH", "RAYLEIGH"] and vunit not in ["m", "cm", "mm", "um"]:
-            log.warn("Wrong unit %s for property %s", vunit, name)
+        length_u = ["m", "cm", "mm", "um"]
+        if name in ["ABSLENGTH", "WLSABSLENGTH", "RAYLEIGH"] and vunit not in length_u:
+            log.warning("Wrong unit %s for property %s", vunit, name)
         if name in ["RINDEX", "WLSCOMPONENT", "REFLECTIVITY"] and vunit != "":
-            log.warn("Wrong unit %s for property %s", vunit, name)
+            log.warning("Wrong unit %s for property %s", vunit, name)
         if eunit not in ["", "eV", "keV", "MeV", "GeV", "TeV" "PeV"]:
-            log.warn("Wrong energy unit %s", eunit)
+            log.warning("Wrong energy unit %s", eunit)
 
         return orig_addVecProperty(self, name, e, v, eunit, vunit)
+
     g4.WithPropertiesBase.addVecProperty = addVecProperty
 
-    orig_addConstProperty = g4.WithPropertiesBase.addConstProperty
-    def addConstProperty(self, name, value):
+    orig_addConstProperty = g4.WithPropertiesBase.addConstProperty  # noqa: N806
+
+    def addConstProperty(self, name, value):  # noqa: N802
         vunit, value = _val_pint_to_gdml(value)
 
         if name in ["SCINTILLATIONYIELD"]:
-            log.warn("%s cannot be used with scintillationByParticleType", name)
+            log.warning("%s cannot be used with scintillationByParticleType", name)
 
         return orig_addConstProperty(self, name, value, vunit)
+
     g4.WithPropertiesBase.addConstProperty = addConstProperty
+
 
 _patch_g4_pint_unit_support()
 
 
-__all__ = ['pyg4_sample_λ', 'pyg4_def_scint_by_particle_type']
+__all__ = ["pyg4_sample_λ", "pyg4_def_scint_by_particle_type"]

--- a/src/legendoptics/silicon.py
+++ b/src/legendoptics/silicon.py
@@ -1,5 +1,4 @@
-"""
-Silicon
+"""Silicon.
 
 .. [Phillip1960] H. R. Phillip and E. A. Taft “Optical Constants of Silicon in the Region 1 to 10 eV”.
    In: Phys. Rev. 120 (1 Oct. 1960)
@@ -11,7 +10,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/tetratex.py
+++ b/src/legendoptics/tetratex.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/tpb.py
+++ b/src/legendoptics/tpb.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 
 import pint
-from numpy.typing import NDArray
 from pint import Quantity
 
 from legendoptics.utils import readdatafile

--- a/src/legendoptics/utils.py
+++ b/src/legendoptics/utils.py
@@ -104,7 +104,7 @@ class InterpolatingGraph:
             return self.vals.iloc[0]
         if pts > self.d_max:
             return self.vals.iloc[-1]
-        return self.fn(pts)
+        return self.fn(pts.to(self.idx.u).m) * self.vals.u
 
 
 class ScintParticle(NamedTuple):

--- a/src/legendoptics/utils.py
+++ b/src/legendoptics/utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import numpy as np
 import pint
 import scipy.interpolate
 from importlib_resources import files
 from numpy.typing import NDArray
-from typing import NamedTuple
 from pint import Quantity
 
 u = pint.get_application_registry()
@@ -58,12 +59,18 @@ class InterpolatingGraph:
     The data points are given as two 1-dimensional NDArrays with units.
     """
 
-    def __init__(self, idx: Quantity, vals: Quantity, min_idx: Quantity = None, max_idx: Quantity = None):
+    def __init__(
+        self,
+        idx: Quantity,
+        vals: Quantity,
+        min_idx: Quantity = None,
+        max_idx: Quantity = None,
+    ):
         # Filter the supplied data points.
         f = np.full(idx.shape, True)
-        if min_idx != None:
+        if min_idx is not None:
             f = f & (idx >= min_idx)
-        if max_idx != None:
+        if max_idx is not None:
             f = f & (idx <= max_idx)
         idx = idx[f]
         vals = vals[f]
@@ -91,7 +98,7 @@ class InterpolatingGraph:
                     [self.vals[0].m, self.fn, self.vals[-1].m],
                 ),
                 self.vals.u,
-             )
+            )
 
         if pts < self.d_min:
             return self.vals.iloc[0]
@@ -102,6 +109,7 @@ class InterpolatingGraph:
 
 class ScintParticle(NamedTuple):
     """Configuration for the scintillation yield relative to the flat-top yield."""
+
     name: str
     yield_factor: float
     exc_ratio: float
@@ -109,5 +117,6 @@ class ScintParticle(NamedTuple):
 
 class ScintConfig(NamedTuple):
     """Scintillation yield parameters, depending on the particle types."""
+
     flat_top: Quantity
     particles: list[ScintParticle]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -6,14 +6,14 @@ u = pint.get_application_registry()
 
 def test_import():
     import legendoptics  # noqa: F401
-    import legendoptics.fibers
-    import legendoptics.lar
-    import legendoptics.tetratex
-    import legendoptics.tpb
-    import legendoptics.germanium
     import legendoptics.copper
+    import legendoptics.fibers
+    import legendoptics.germanium
+    import legendoptics.lar
     import legendoptics.nylon
     import legendoptics.silicon
+    import legendoptics.tetratex
+    import legendoptics.tpb
 
     legendoptics.lar.lar_fano_factor()
     legendoptics.lar.lar_emission_spectrum()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -23,6 +23,10 @@ def test_import():
     legendoptics.lar.lar_dielectric_constant(wvl)
     legendoptics.lar.lar_refractive_index(wvl)
     legendoptics.lar.lar_rayleigh(wvl, 87 * u.K)
+    legendoptics.lar.lar_abs_length(wvl)
+    legendoptics.lar.lar_peak_attenuation_length()
+    legendoptics.lar.lar_lifetimes()
+    legendoptics.lar.lar_scintillation_params()
 
     legendoptics.tpb.tpb_quantum_efficiency()
     legendoptics.tpb.tpb_refractive_index()


### PR DESCRIPTION
This contains mainly of two parts:
1. it adds the remaining LAr properties (even those with a more "hand-wavy" implementation, i.e. the absorption length)
2. it adds a "glue" function that adds all properties together and attaches them to a given Geant4 material

The split-up into the two util-submodules is intentional, as well as the local import of the pyg4ometry stuff in `lar.py` - with this `pyg4ometry` will only be loaded if requested (and not, if someone just accesses the raw properties)

---

This also contains some fixes to work with pint `Quantity[NDArray]`, and not just ndarray of individual quantities...

The helper types for scintillation are added to group together physical quantities that will usually come from a low nuber of publications, so that we don't need 7 functions with equal/similar docstrings. Also it might be helpful for other materials.