### PR TITLE
docs: add plots of optical properties

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from pkg_resources import get_distribution
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
+# Add local extension directory.
+sys.path.insert(0, (Path(__file__).parents[0] / "exts").as_posix())
 
 project = "legend-pygeom-optics"
 copyright = "The LEGEND Collaboration"
@@ -19,6 +21,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "myst_parser",
+    "optics_plot_extension",
 ]
 
 source_suffix = {

--- a/docs/source/exts/optics_plot_extension.py
+++ b/docs/source/exts/optics_plot_extension.py
@@ -14,35 +14,74 @@ u = pint.get_application_registry()
 
 
 def do_plot(obj: Callable, fn: str, options: dict[str, Any]):
-    """Create a plot from the given optical property function."""
+    """Create a plot from the given optical property function.
+
+    By default, it will call ``obj()`` and unpack the result into an x-vector, and multiple
+    y-vectors. All y-vectors will pe plotted together into one output file.
+
+    Other parameters
+    ----------------
+    options
+        Change the behaviour of the plot.
+
+        xlim
+            Set the plot's x axis limits, see :py:func:`matplotlib.pyplot.xlim`
+        ylim
+            Set the plot's y axis limits, see :py:func:`matplotlib.pyplot.ylim`
+        xscale
+            Set the plot's x axis scaling, see :py:func:`matplotlib.pyplot.xscale`
+        yscale
+            Set the plot's y axis scaling, see :py:func:`matplotlib.pyplot.yscale`
+        labels
+            Tuple of labels that will be applied if more than one y vector is returned.
+        call_x
+            Differing from the default behavior above, the function will be called with an
+            x vector of wavelengths in the optical range (as :py:class:`pint.Quantity`).
+            All return values are interpreted as y vectors.
+    """
     # init plot
     fig = plt.figure(figsize=(4, 2))
     ax = plt.gca()
     plt.grid()
 
     if "call_x" in options:
-        # special case for LAr properties.
+        # special case for LAr properties
         x = np.linspace(112 * u.nm, 650 * u.nm, num=200)
-        y = obj(x)
+        ys = obj(x)
+        # wrap the result in a tuple, if needed
+        ys = ys if isinstance(ys, tuple) else (ys,)
     else:
-        x, y = obj()
+        data = obj()
+        x = data[0]
+        # ys holds one or more
+        ys = data[1:]
 
     if isinstance(x, pint.Quantity):
         ax.set_xlabel(x.u)
         x = x.magnitude
-    if isinstance(y, pint.Quantity):
-        ax.set_ylabel(y.u)
-        y = y.magnitude
-    plt.plot(x, y, marker=".", markersize=2, linewidth=0.5)
+
+    # plot all supplied data vectors
+    i = 0
+    for y in ys:
+        if isinstance(y, pint.Quantity):
+            ax.set_ylabel(y.u)
+            y = y.magnitude
+
+        plotoptions = {}
+        if "labels" in options:
+            plotoptions["label"] = options["labels"][i]
+
+        plt.plot(x, y, marker=".", markersize=2, linewidth=0.5, **plotoptions)
+        i += 1
+
+    if len(ys) > 1 and "labels" in options:
+        plt.legend()
 
     # adjust plotting options
     if "ylim" in options:
         ax.set_ylim(options["ylim"])
     if "xlim" in options:
         ax.set_xlim(options["xlim"])
-    if "yright" in options:
-        ax.yaxis.set_label_position("right")
-        ax.yaxis.tick_right()
     if "yscale" in options:
         ax.set_yscale(options["yscale"])
     if "xscale" in options:
@@ -63,7 +102,8 @@ def process_docstring(
 
     plots_dir = Path(app.srcdir) / "api" / "plots"
 
-    plot_token = "..optics-plot::"
+    # this only appears to be a sphix directive, but the parsing here is very simple.
+    plot_token = ".. optics-plot::"
 
     i = 0
     for line in lines:
@@ -78,6 +118,8 @@ def process_docstring(
                 opts = ast.literal_eval(opt_string)
 
             do_plot(obj, fn, opts)
+
+            # replace the custom 'directive' with an actually supported reST directive.
             lines[i] = f".. image:: plots/{safe_name}.png"
         i += 1
 

--- a/docs/source/exts/optics_plot_extension.py
+++ b/docs/source/exts/optics_plot_extension.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any, Callable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pint
+from sphinx.application import Sphinx
+
+u = pint.get_application_registry()
+
+
+def do_plot(obj: Callable, fn: str, options: dict[str, Any]):
+    """Create a plot from the given optical property function."""
+    # init plot
+    fig = plt.figure(figsize=(4, 2))
+    ax = plt.gca()
+    plt.grid()
+
+    if "call_x" in options:
+        # special case for LAr properties.
+        x = np.linspace(112 * u.nm, 650 * u.nm, num=200)
+        y = obj(x)
+    else:
+        x, y = obj()
+
+    if isinstance(x, pint.Quantity):
+        ax.set_xlabel(x.u)
+        x = x.magnitude
+    if isinstance(y, pint.Quantity):
+        ax.set_ylabel(y.u)
+        y = y.magnitude
+    plt.plot(x, y, marker=".", markersize=2, linewidth=0.5)
+
+    # adjust plotting options
+    if "ylim" in options:
+        ax.set_ylim(options["ylim"])
+    if "xlim" in options:
+        ax.set_xlim(options["xlim"])
+    if "yright" in options:
+        ax.yaxis.set_label_position("right")
+        ax.yaxis.tick_right()
+    if "yscale" in options:
+        ax.set_yscale(options["yscale"])
+    if "xscale" in options:
+        ax.set_xscale(options["xscale"])
+
+    # export figure to the filesystem
+    fig.tight_layout(pad=0.3)
+    fig.savefig(fn)
+
+
+def process_docstring(
+    app: Sphinx, what: str, name: str, obj: Any, options: Any, lines: list[str]
+) -> None:
+    if inspect.isclass(obj) or what != "function":
+        return
+    if not callable(obj):
+        return
+
+    plots_dir = Path(app.srcdir) / "api" / "plots"
+
+    plot_token = "..optics-plot::"
+
+    i = 0
+    for line in lines:
+        if line.startswith(plot_token):
+            plots_dir.mkdir(exist_ok=True, parents=True)
+            safe_name = "".join(c for c in name if c.isalnum() or c in (".", "-", "_"))
+            fn = plots_dir / (safe_name + ".png")
+
+            opt_string = line[len(plot_token) :]
+            opts = []
+            if opt_string != "":
+                opts = ast.literal_eval(opt_string)
+
+            do_plot(obj, fn, opts)
+            lines[i] = f".. image:: plots/{safe_name}.png"
+        i += 1
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    """Register this sphinx extension."""
+    app.connect("autodoc-process-docstring", process_docstring)
+    return dict(parallel_read_safe=True)

--- a/docs/source/exts/optics_plot_extension.py
+++ b/docs/source/exts/optics_plot_extension.py
@@ -21,7 +21,7 @@ def do_plot(
     By default, it will call ``obj()`` and unpack the result into an x-vector, and multiple
     y-vectors. All y-vectors will pe plotted together into one output file.
 
-    Other parameters
+    Other Parameters
     ----------------
     options
         Change the behaviour of the plot.

--- a/src/legendoptics/copper.py
+++ b/src/legendoptics/copper.py
@@ -14,7 +14,10 @@ u = pint.get_application_registry()
 
 
 def copper_reflectivity() -> tuple[Quantity, Quantity]:
-    """Measurements from [Wegmann2017]_."""
+    """Measurements from [Wegmann2017]_.
+
+    ..optics-plot::
+    """
     return readdatafile("cu_reflectivity.dat")
 
 

--- a/src/legendoptics/copper.py
+++ b/src/legendoptics/copper.py
@@ -16,7 +16,7 @@ u = pint.get_application_registry()
 def copper_reflectivity() -> tuple[Quantity, Quantity]:
     """Measurements from [Wegmann2017]_.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     return readdatafile("cu_reflectivity.dat")
 

--- a/src/legendoptics/fibers.py
+++ b/src/legendoptics/fibers.py
@@ -18,17 +18,26 @@ u = pint.get_application_registry()
 
 
 def fiber_cladding2_refractive_index() -> float:
-    """Refractive index of second fiber cladding material [SaintGobainDataSheet]_."""
+    """Refractive index of second fiber cladding material [SaintGobainDataSheet]_.
+
+    .. optics-const::
+    """
     return 1.42
 
 
 def fiber_cladding1_refractive_index() -> float:
-    """Refractive index of first fiber cladding material [SaintGobainDataSheet]_."""
+    """Refractive index of first fiber cladding material [SaintGobainDataSheet]_.
+
+    .. optics-const::
+    """
     return 1.49
 
 
 def fiber_core_refractive_index() -> float:
-    """Refractive index of fiber core material [SaintGobainDataSheet]_."""
+    """Refractive index of fiber core material [SaintGobainDataSheet]_.
+
+    .. optics-const::
+    """
     return 1.6
 
 
@@ -74,22 +83,28 @@ def fiber_wls_emission() -> tuple[Quantity, Quantity]:
     return readdatafile("psfibers_wlscomponent.dat")
 
 
-def fiber_wls_timeconstant() -> float:
-    """WLS time constant [SaintGobainDataSheet]_."""
+def fiber_wls_timeconstant() -> Quantity:
+    """WLS time constant [SaintGobainDataSheet]_.
+
+    .. optics-const::
+    """
     return 12 * u.ns
 
 
-def fiber_absorption_length() -> float:
+def fiber_absorption_length() -> Quantity:
     """Absorption length of fiber [SaintGobainDataSheet]_. Note this is a macroscopical value for a 1 mm fiber.
 
     See Also
     --------
     .fiber_absorption_path_length
+
+
+    .. optics-const::
     """
     return 3.5 * u.m
 
 
-def fiber_absorption_path_length() -> float:
+def fiber_absorption_path_length() -> Quantity:
     """Absorption length of fiber [SaintGobainDataSheet]_, corrected for the geometry of a 1 mm square fiber.
 
     Multiplied by an empirical factor to account for the prolonged path length inside a square fiber with 1mm side length.
@@ -97,6 +112,9 @@ def fiber_absorption_path_length() -> float:
     See Also
     --------
     .fiber_absorption_length
+
+
+    .. optics-const::
     """
     return fiber_absorption_length() * 1.21
 

--- a/src/legendoptics/fibers.py
+++ b/src/legendoptics/fibers.py
@@ -56,6 +56,8 @@ def fiber_wls_absorption(
 
     Measured an absorption length of 0.7 mm at 400 nm, the spectrum has been rescaled by
     that.
+
+    ..optics-plot::
     """
     wvl, absorp = readdatafile("psfibers_wlsabslength.dat")  # arbitrary unit
     assert str(absorp.dimensionality) == "dimensionless"

--- a/src/legendoptics/fibers.py
+++ b/src/legendoptics/fibers.py
@@ -57,7 +57,7 @@ def fiber_wls_absorption(
     Measured an absorption length of 0.7 mm at 400 nm, the spectrum has been rescaled by
     that.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     wvl, absorp = readdatafile("psfibers_wlsabslength.dat")  # arbitrary unit
     assert str(absorp.dimensionality) == "dimensionless"
@@ -67,7 +67,10 @@ def fiber_wls_absorption(
 
 
 def fiber_wls_emission() -> tuple[Quantity, Quantity]:
-    """[SaintGobainDataSheet]_ reports the emission spectrum for BCF-91A."""
+    """[SaintGobainDataSheet]_ reports the emission spectrum for BCF-91A.
+
+    .. optics-plot::
+    """
     return readdatafile("psfibers_wlscomponent.dat")
 
 

--- a/src/legendoptics/germanium.py
+++ b/src/legendoptics/germanium.py
@@ -19,7 +19,10 @@ u = pint.get_application_registry()
 
 
 def germanium_reflectivity() -> tuple[Quantity, Quantity]:
-    """Measurements from [Wegmann2017]_ (with GERDA dead-layer Li-doped germanium, at room temperature)."""
+    """Measurements from [Wegmann2017]_ (with GERDA dead-layer Li-doped germanium, at room temperature).
+
+    ..optics-plot::
+    """
     return readdatafile("ge_reflectivity.dat")
 
 

--- a/src/legendoptics/germanium.py
+++ b/src/legendoptics/germanium.py
@@ -21,7 +21,7 @@ u = pint.get_application_registry()
 def germanium_reflectivity() -> tuple[Quantity, Quantity]:
     """Measurements from [Wegmann2017]_ (with GERDA dead-layer Li-doped germanium, at room temperature).
 
-    ..optics-plot::
+    .. optics-plot::
     """
     return readdatafile("ge_reflectivity.dat")
 

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -144,7 +144,9 @@ def lar_fano_factor() -> float:
     """Fano factor.
 
     Statistical yield fluctuation can be broadened or narrower
-    (impurities, fano factor). Value 0.11 from [Doke1976]_.
+    (impurities, fano factor). Value from [Doke1976]_.
+
+    .. optics-const::
     """
     return 0.11
 

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -54,6 +54,8 @@ def lar_dielectric_constant_bideau_mehu(
 
     From the Bideau-Sellmeier formula [Bideau-Mehu1980]_ in gaseous argon,
     density-corrected for liquid argon.
+
+    ..optics-plot:: {'call_x': True}
     """
     if not λ.check("[length]"):
         raise ValueError("input does not look like a wavelength")
@@ -80,6 +82,8 @@ def lar_dielectric_constant_cern2020(
     """Calculate the dielectric constant of LAr for a given photon wavelength.
 
     From [Babicz2020]_ (measurements in LAr).
+
+    ..optics-plot:: {'call_x': True}
     """
     if not λ.check("[length]"):
         raise ValueError("input does not look like a wavelength")
@@ -121,12 +125,18 @@ def lar_refractive_index(λ: Quantity, method: str = "cern2020") -> Quantity:
     See Also
     --------
     .lar_dielectric_constant
+
+
+    ..optics-plot:: {'call_x': True}
     """
     return np.sqrt(lar_dielectric_constant(λ, method))
 
 
 def lar_emission_spectrum() -> tuple[Quantity, Quantity]:
-    """Return the LAr emission spectrum, adapted from [Heindl2010]_."""
+    """Return the LAr emission spectrum, adapted from [Heindl2010]_.
+
+    ..optics-plot::
+    """
     return readdatafile("lar_emission_heindl2010.dat")
 
 
@@ -182,6 +192,8 @@ def lar_abs_length(λ: Quantity) -> Quantity:
     range just to avoid a step-like function. Still is a guess.
     This function has to be re-scaled with the intended attenuation length at the VUV
     emission peak.
+
+    ..optics-plot:: {'call_x': True}
     """
     λ = np.maximum(λ, 141 * u.nm)
     absl = 5.976e-12 * np.exp(0.223 * λ.to("nm").m) * u.cm

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -152,7 +152,7 @@ def lar_fano_factor() -> float:
 
 
 def lar_rayleigh(
-    λ: Quantity, temperature: Quantity, method: str = "cern2020"
+    λ: Quantity, temperature: Quantity = 90 * u.K, method: str = "cern2020"
 ) -> Quantity:
     """Calculate the Rayleigh scattering length using the equations given in [Seidel2002]_.
 
@@ -163,6 +163,9 @@ def lar_rayleigh(
     See Also
     --------
     .lar_dielectric_constant
+
+
+    .. optics-plot:: {'call_x': True}
     """
     if not temperature.check("[temperature]"):
         raise ValueError("input does not look like a temperature")
@@ -247,17 +250,17 @@ def lar_scintillation_params(flat_top_yield: Quantity = 31250 / u.MeV) -> ScintC
 
     For flat-top response particles the mean energy to produce a photon is 19.5 eV
 
-    .. math:: Y = 1/(19.5 eV) = 0.051 eV^{-1}
+    .. math:: Y = 1/(19.5 \\mathrm{eV}) = 0.051 \\mathrm{eV}^{-1}
 
     At zero electric field, for not-flat-top particles, the scintillation yield,
     relative to the one of flat top particles is:
+
     .. math::
+        Y_\\texrm{e} &= 0.8 Y
 
-        Y_e = 0.8 Y
+        Y_\\texrm{alpha} &= 0.7 Y
 
-        Y_alpha = 0.7 Y
-
-        Y_recoils = 0.2-0.4
+        Y_\\texrm{recoils} &= 0.2\\textrm{--}0.4
 
     Excitation ratio:
     For example, for nuclear recoils it should be 0.75

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -241,7 +241,7 @@ def lar_lifetimes(
 
 
 def lar_scintillation_params(flat_top_yield: Quantity = 31250 / u.MeV) -> ScintConfig:
-    """Scintillation yield (approx. inverse of the mean energy to produce a UV photon).
+    r"""Scintillation yield (approx. inverse of the mean energy to produce a UV photon).
 
     This depends on the nature of the impinging particles, the field configuration
     and the quencher impurities. We set here just a reference value that is lower than
@@ -250,17 +250,17 @@ def lar_scintillation_params(flat_top_yield: Quantity = 31250 / u.MeV) -> ScintC
 
     For flat-top response particles the mean energy to produce a photon is 19.5 eV
 
-    .. math:: Y = 1/(19.5 \\mathrm{eV}) = 0.051 \\mathrm{eV}^{-1}
+    .. math:: Y = 1/(19.5 \mathrm{eV}) = 0.051 \mathrm{eV}^{-1}
 
     At zero electric field, for not-flat-top particles, the scintillation yield,
     relative to the one of flat top particles is:
 
     .. math::
-        Y_\\texrm{e} &= 0.8 Y
+        Y_\texrm{e} &= 0.8 Y
 
-        Y_\\texrm{alpha} &= 0.7 Y
+        Y_\texrm{alpha} &= 0.7 Y
 
-        Y_\\texrm{recoils} &= 0.2\\textrm{--}0.4
+        Y_\texrm{recoils} &= 0.2\textrm{--}0.4
 
     Excitation ratio:
     For example, for nuclear recoils it should be 0.75

--- a/src/legendoptics/lar.py
+++ b/src/legendoptics/lar.py
@@ -55,7 +55,7 @@ def lar_dielectric_constant_bideau_mehu(
     From the Bideau-Sellmeier formula [Bideau-Mehu1980]_ in gaseous argon,
     density-corrected for liquid argon.
 
-    ..optics-plot:: {'call_x': True}
+    .. optics-plot:: {'call_x': True}
     """
     if not λ.check("[length]"):
         raise ValueError("input does not look like a wavelength")
@@ -83,7 +83,7 @@ def lar_dielectric_constant_cern2020(
 
     From [Babicz2020]_ (measurements in LAr).
 
-    ..optics-plot:: {'call_x': True}
+    .. optics-plot:: {'call_x': True}
     """
     if not λ.check("[length]"):
         raise ValueError("input does not look like a wavelength")
@@ -127,7 +127,7 @@ def lar_refractive_index(λ: Quantity, method: str = "cern2020") -> Quantity:
     .lar_dielectric_constant
 
 
-    ..optics-plot:: {'call_x': True}
+    .. optics-plot:: {'call_x': True}
     """
     return np.sqrt(lar_dielectric_constant(λ, method))
 
@@ -135,7 +135,7 @@ def lar_refractive_index(λ: Quantity, method: str = "cern2020") -> Quantity:
 def lar_emission_spectrum() -> tuple[Quantity, Quantity]:
     """Return the LAr emission spectrum, adapted from [Heindl2010]_.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     return readdatafile("lar_emission_heindl2010.dat")
 
@@ -193,7 +193,7 @@ def lar_abs_length(λ: Quantity) -> Quantity:
     This function has to be re-scaled with the intended attenuation length at the VUV
     emission peak.
 
-    ..optics-plot:: {'call_x': True}
+    .. optics-plot:: {'call_x': True}
     """
     λ = np.maximum(λ, 141 * u.nm)
     absl = 5.976e-12 * np.exp(0.223 * λ.to("nm").m) * u.cm

--- a/src/legendoptics/nylon.py
+++ b/src/legendoptics/nylon.py
@@ -31,7 +31,7 @@ def nylon_refractive_index() -> float:
 def nylon_absorption() -> tuple[Quantity, Quantity]:
     """Values reported in [Agostini2018]_.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     wvl, absorp = readdatafile("nylon_absorption.dat")
     assert absorp.check("[length]")

--- a/src/legendoptics/nylon.py
+++ b/src/legendoptics/nylon.py
@@ -24,7 +24,10 @@ u = pint.get_application_registry()
 
 
 def nylon_refractive_index() -> float:
-    """Refractive index in near-UV range, from [Benziger2007]_."""
+    """Refractive index in near-UV range, from [Benziger2007]_.
+
+    .. optics-const::
+    """
     return 1.53
 
 

--- a/src/legendoptics/nylon.py
+++ b/src/legendoptics/nylon.py
@@ -29,7 +29,10 @@ def nylon_refractive_index() -> float:
 
 
 def nylon_absorption() -> tuple[Quantity, Quantity]:
-    """Values reported in [Agostini2018]_."""
+    """Values reported in [Agostini2018]_.
+
+    ..optics-plot::
+    """
     wvl, absorp = readdatafile("nylon_absorption.dat")
     assert absorp.check("[length]")
     return wvl, absorp

--- a/src/legendoptics/silicon.py
+++ b/src/legendoptics/silicon.py
@@ -19,7 +19,10 @@ u = pint.get_application_registry()
 
 
 def silicon_complex_rindex() -> tuple[Quantity, Quantity, Quantity]:
-    """Real and imaginary parts as tuple(wavelength, Re, Im). Measurements from [Phillip1960]_."""
+    """Real and imaginary parts as tuple(wavelength, Re, Im). Measurements from [Phillip1960]_.
+
+    .. optics-plot:: {'labels':('Re n','Im n')}
+    """
     real = readdatafile("si_rindex_real.dat")
     imag = readdatafile("si_rindex_imag.dat")
     assert (real[0] == imag[0]).all()

--- a/src/legendoptics/tetratex.py
+++ b/src/legendoptics/tetratex.py
@@ -23,6 +23,8 @@ def tetratex_reflectivity() -> tuple[Quantity, Quantity]:
     Tetratex. As our layer in GERDA/LEGEND is 254um thick I'm taking here his results
     for the two superimposed foils (= 320um). So, in reality, the reflectivity
     of our foil should be (negligibly) smaller.
+
+    ..optics-plot::
     """
     return readdatafile("tetratex_reflectivity.dat")
 

--- a/src/legendoptics/tetratex.py
+++ b/src/legendoptics/tetratex.py
@@ -24,7 +24,7 @@ def tetratex_reflectivity() -> tuple[Quantity, Quantity]:
     for the two superimposed foils (= 320um). So, in reality, the reflectivity
     of our foil should be (negligibly) smaller.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     return readdatafile("tetratex_reflectivity.dat")
 

--- a/src/legendoptics/tpb.py
+++ b/src/legendoptics/tpb.py
@@ -34,17 +34,25 @@ def tpb_quantum_efficiency() -> float:
 
     * Current literature value of 0.85 from [Araujo2022]_ at LAr Temperature.
     * Other measurement from [Benson2018]_ reports ~0.6 at room temperature
+
+    .. optics-const::
     """
     return 0.85
 
 
 def tpb_refractive_index() -> float:
-    """Refractive index from [MolbaseTPB]_."""
+    """Refractive index from [MolbaseTPB]_.
+
+    .. optics-const::
+    """
     return 1.635
 
 
 def tpb_wls_timeconstant() -> Quantity:
-    """Time constant: arbitrary small."""
+    """Time constant: arbitrary small.
+
+    .. optics-const::
+    """
     return 0.01 * u.ns
 
 

--- a/src/legendoptics/tpb.py
+++ b/src/legendoptics/tpb.py
@@ -55,12 +55,17 @@ def tpb_wls_emission() -> tuple[Quantity, Quantity]:
     at an excitation wavelength of 128nm and at 87K, so exactly in our experimental
     conditions. The major differences brougth by the LAr temperature are the vibronic
     structures that modify the shape of the spectrum.
+
+    ..optics-plot::
     """
     return readdatafile("tpb_vm2000_wlscomponent.dat")
 
 
 def tpb_wls_absorption() -> tuple[Quantity, Quantity]:
-    """Values reported in [Benson2018]_ for TPB evaporated on utraviolet-transmitting acrylic substrate."""
+    """Values reported in [Benson2018]_ for TPB evaporated on utraviolet-transmitting acrylic substrate.
+
+    ..optics-plot:: {'yscale': 'log'}
+    """
     wvl, absorp = readdatafile("tpb_wlsabslength.dat")
     assert absorp.check("[length]")
     return wvl, absorp

--- a/src/legendoptics/tpb.py
+++ b/src/legendoptics/tpb.py
@@ -56,7 +56,7 @@ def tpb_wls_emission() -> tuple[Quantity, Quantity]:
     conditions. The major differences brougth by the LAr temperature are the vibronic
     structures that modify the shape of the spectrum.
 
-    ..optics-plot::
+    .. optics-plot::
     """
     return readdatafile("tpb_vm2000_wlscomponent.dat")
 
@@ -64,7 +64,7 @@ def tpb_wls_emission() -> tuple[Quantity, Quantity]:
 def tpb_wls_absorption() -> tuple[Quantity, Quantity]:
     """Values reported in [Benson2018]_ for TPB evaporated on utraviolet-transmitting acrylic substrate.
 
-    ..optics-plot:: {'yscale': 'log'}
+    .. optics-plot:: {'yscale': 'log'}
     """
     wvl, absorp = readdatafile("tpb_wlsabslength.dat")
     assert absorp.check("[length]")


### PR DESCRIPTION
This will be replaced by an image of the plot.
```
.. optics-plot:: {'yscale': 'log'}
```

The options dictionary is optional and allows to specify some plotting options (e.g. plotting axes logarithmically or specifying axes limits).
The option `call_x` is special and will _call_ the function with an x-vector as an argument, otherwise a function without parameters is assumed.

Also
```
.. optics-const::
```
is supported (without any parameters) to include the numerical return value