### PR TITLE
More pint compatibility fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy<2.0 ; python_version <= '3.9'",
-    "numpy ; python_version >= '3.10'",
-    "pint",
+    "numpy",
+    "pint >= 0.24.1",
     "pyg4ometry",
     "pylegendmeta>=v0.9.0a2",
     "pyarrow",

--- a/src/legendoptics/pyg4utils.py
+++ b/src/legendoptics/pyg4utils.py
@@ -93,7 +93,7 @@ def _patch_g4_pint_unit_support() -> None:
 
         base_unit = v.units
 
-        unit = "{base_unit:~gdml}"
+        unit = f"{base_unit:~gdml}"
         assert unit == f"{base_unit:~}".replace(" ", "").replace("µ", "u")
         assert "dimensionless" not in unit
 

--- a/src/legendoptics/pyg4utils.py
+++ b/src/legendoptics/pyg4utils.py
@@ -66,7 +66,7 @@ def pyg4_def_scint_by_particle_type(mat, scint_cfg: ScintConfig) -> None:
 
 @pint.register_unit_format("gdml")
 def _gdml_format(unit, registry, **options):
-    proc = {ureg._get_symbol(u).replace("µ", "u"): e for u, e in unit.items()}
+    proc = {u.replace("µ", "u"): e for u, e in unit.items()}
     return pint.formatting.formatter(
         proc.items(),
         as_ratio=True,
@@ -93,8 +93,7 @@ def _patch_g4_pint_unit_support() -> None:
 
         base_unit = v.units
 
-        # TODO: drop the extra check for dimensionless quantities after dropping support for pint <= 0.23
-        unit = "" if v.check("1") else f"{base_unit:gdml}"
+        unit = "{base_unit:~gdml}"
         assert unit == f"{base_unit:~}".replace(" ", "").replace("µ", "u")
         assert "dimensionless" not in unit
 


### PR DESCRIPTION
* [x] Use the "correct" way to get a numeric value from a pint quantity, don't use string conversion
* [x] Correct `pyproject.toml` for Pint 0.24.1 (only after release)
    * this will support (again) python < 3.9 and will fix at least two important formatting-related B/C breaks
* [x] See if we can drop the pint 0.23 code from #56 and require `pint >= 0.24` for all our supported python versions?