### PR TITLE
add function to sample scintillation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pyg4ometry",
     "pylegendmeta>=v0.9.0a2",
     "pyarrow",
+    "scipy",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "numba",
     "numpy",
     "pint >= 0.24.1",
     "pyg4ometry",

--- a/src/legendoptics/pyg4utils.py
+++ b/src/legendoptics/pyg4utils.py
@@ -7,7 +7,7 @@ import pint
 import pyg4ometry.geant4 as g4
 from pint import Quantity
 
-from .utils import ScintConfig
+from .scintillate import ScintConfig
 
 log = logging.getLogger(__name__)
 ureg = pint.get_application_registry().get()
@@ -55,6 +55,12 @@ def _def_scint_particle(
 def pyg4_def_scint_by_particle_type(mat, scint_cfg: ScintConfig) -> None:
     """Define a full set of particles for scintillation."""
     for particle in scint_cfg.particles:
+        if not particle.valid_geant_particle():
+            msg = (
+                f"Unknown particle type {particle.name} for ScintillationByParticleType"
+            )
+            raise ValueError(msg)
+
         _def_scint_particle(
             mat,
             particle.name.upper(),

--- a/src/legendoptics/scintillate.py
+++ b/src/legendoptics/scintillate.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from typing import Literal, NamedTuple, NewType, Optional, get_args, get_type_hints
+
+import numpy as np
+import pint
+from numba import njit
+from pint import Quantity
+
+u = pint.get_application_registry()
+
+
+class ScintParticle(NamedTuple):
+    """Configuration for the scintillation yield relative to the flat-top yield."""
+
+    name: Literal["deuteron", "triton", "alpha", "ion", "electron"]
+    yield_factor: float
+    exc_ratio: Optional[float]  # noqa: UP007
+
+    def valid_geant_particle(self) -> bool:
+        return self.name.lower() in get_args(get_type_hints(ScintParticle)["name"])
+
+
+class ScintConfig(NamedTuple):
+    """Scintillation yield parameters, depending on the particle types."""
+
+    flat_top: Quantity
+    fano_factor: Optional[float]  # noqa: UP007
+    particles: list[ScintParticle]
+
+    def get_particle(self, name: str) -> Optional[ScintParticle]:  # noqa: UP007
+        for p in self.particles:
+            if p.name.upper() == name.upper():
+                return p
+        return None
+
+
+ParticleIndex = NewType("ParticleIndex", int)
+ComputedScintParams = NewType(
+    "ComputedScintParams", tuple[float, float, np.ndarray, np.ndarray]
+)
+PARTICLE_INDICES = {"electron": 0, "alpha": 1, "ion": 2, "deuteron": 3, "triton": 4}
+
+
+def precompute_scintillation_params(
+    scint_config: ScintConfig,
+    time_components: tuple[Quantity, ...],
+) -> ComputedScintParams:
+    # validate that we have a valid configuration of scintillation parameters.
+    part_with_exc_ratio = [1 for p in scint_config.particles if p.exc_ratio is not None]
+    if len(part_with_exc_ratio) not in (0, len(scint_config.particles)):
+        msg = "Not all particles have exc_ratio defined"
+        raise ValueError(msg)
+    has_2_timeconstants = len(part_with_exc_ratio) > 0
+    if len(time_components) != (1 + int(has_2_timeconstants)):
+        msg = "Number of time_components is not as required"
+        raise ValueError(msg)
+
+    particles = np.zeros((len(PARTICLE_INDICES), (2 + int(has_2_timeconstants))))
+
+    electron = scint_config.get_particle("electron")
+    if electron is None:
+        raise ValueError()
+    for k, v in PARTICLE_INDICES.items():
+        p = scint_config.get_particle(k)
+        p = electron if p is None else p
+        if has_2_timeconstants:
+            particles[v] = np.array([p.yield_factor, p.exc_ratio, 1 - p.exc_ratio])
+        else:
+            particles[v] = np.array([p.yield_factor, 1])
+
+    time_components = np.array([t.to(u.nanosecond).m for t in time_components])
+    fano = scint_config.fano_factor if scint_config.fano_factor is not None else 1
+
+    return scint_config.flat_top.to("1/keV").m, fano, time_components, particles
+
+
+def particle_to_index(particle: str) -> ParticleIndex:
+    """Converts the given G4 scintillation particle name to a module-internal index."""
+    return PARTICLE_INDICES[particle.lower()]
+
+
+@njit
+def scintillate_local(
+    params: ComputedScintParams,
+    particle: ParticleIndex,
+    edep_keV: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Generates a Poisson/Gauss-distributed number of photons according to the
+    scintillation yield formula, as implemented in Geant4.
+
+    This function only calculates the local part of scintillation.
+
+    Parameters
+    ----------
+    params
+        scintillation parameter tuple, as created by :meth:`precompute_scintillation_params`.
+    particle
+        module-internal particle index, see :meth:`particle_to_index`.
+    edep_keV
+        energy deposition along this step, in units pf keV.
+
+    Returns
+    -------
+    array of scintillation time stamps in nanoseconds, relative to the point in
+    time of energy deposition.
+    """
+    flat_top, fano, time_components, particles = params
+
+    # get the particle scintillation info.
+    if particle < 0 or particle > particles.shape[0]:
+        msg = "unknown particle index"
+        raise IndexError(msg)
+    part = particles[particle]
+    yield_factor = part[0]
+    yields = part[1:]
+
+    mean_num_phot = flat_top * yield_factor * edep_keV
+
+    # derive the actual number of photons generated in this step.
+    if mean_num_phot > 10:
+        sigma = np.sqrt(fano * mean_num_phot)
+        num_photons = int(rng.normal(mean_num_phot, sigma) + 0.5)
+    else:
+        num_photons = rng.poisson(mean_num_phot)
+
+    if num_photons <= 0:
+        return np.empty((0,))
+
+    # derive number of photons for all time components.
+    yields = (num_photons * yields).astype(np.int64)
+    yields[-1] = num_photons - np.sum(yields[0:-1])  # to keep the sum constant.
+
+    # now, calculate the timestamps of each generated photon.
+    times = np.log(rng.uniform(size=num_photons))
+    start = 0
+    for num_phot, scint_t in zip(yields, time_components):
+        times[start : start + num_phot] *= -scint_t
+        start += num_phot
+
+    return times
+
+
+@njit
+def scintillate(
+    params: ComputedScintParams,
+    x0_m: np.ndarray,
+    x1_m: np.ndarray,
+    v0_mpns: float,
+    v1_mpns: float,
+    t0_ns: float,
+    particle: ParticleIndex,
+    particle_charge: int,
+    edep_keV: float,
+    rng: np.random.Generator,
+):
+    """Generates a Poisson/Gauss-distributed number of photons according to the
+    scintillation yield formula, as implemented in Geant4, along the line segment
+    between x0 and x1.
+
+    Parameters
+    ----------
+    params
+        scintillation parameter tuple, as created by :meth:`precompute_scintillation_params`.
+    x0_m
+        three-vector of pre step point position (in units of meter).
+    x1_m
+        three-vector of post step point position (in units of meter).
+    v0_mpns
+        velocity of particle before step (in units of meter per nanosecond).
+    v1_mpns
+        velocity of particle after step (in units of meter per nanosecond).
+    t0_ns
+        global time offset of step start in scintillator, in nanoseconds.
+    particle
+        module-internal particle index, see :meth:`particle_to_index`.
+    particle_charge
+        charge of the particle, in units of the elementary charge.
+    edep_keV
+        energy deposition along this step, in units pf keV.
+
+    Returns
+    -------
+    array of four-vectors containing time stamps (in nanoseconds) and global scintillation
+    positions (in meter).
+    """
+    delta_t_scint = scintillate_local(params, particle, edep_keV, rng)
+    # emission position for each single photon.
+    if particle_charge != 0:
+        λ = rng.uniform(size=delta_t_scint.shape[0])
+    else:
+        λ = np.ones(shape=delta_t_scint.shape[0])
+
+    x = np.empty((delta_t_scint.shape[0], 4))
+    # spatial components along the line segment between x0 and x1.
+    x[:, 1] = x0_m[0] + λ * (x1_m[0] - x0_m[0])
+    x[:, 2] = x0_m[1] + λ * (x1_m[1] - x0_m[1])
+    x[:, 3] = x0_m[2] + λ * (x1_m[2] - x0_m[2])
+
+    # time component along the velocity decrease between x0 and x1.
+    x[:, 0] = np.linalg.norm(x1_m - x0_m) / (v0_mpns + λ * (v1_mpns - v0_mpns) / 2)
+    # add the global time offset and the emission time offset.
+    x[:, 0] += t0_ns + delta_t_scint
+
+    return x

--- a/src/legendoptics/utils.py
+++ b/src/legendoptics/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import NamedTuple
 
 import numpy as np
 import pint
@@ -106,21 +105,6 @@ class InterpolatingGraph:
         if pts > self.d_max:
             return self.vals.iloc[-1]
         return self.fn(pts.to(self.idx.u).m) * self.vals.u
-
-
-class ScintParticle(NamedTuple):
-    """Configuration for the scintillation yield relative to the flat-top yield."""
-
-    name: str
-    yield_factor: float
-    exc_ratio: float | None
-
-
-class ScintConfig(NamedTuple):
-    """Scintillation yield parameters, depending on the particle types."""
-
-    flat_top: Quantity
-    particles: list[ScintParticle]
 
 
 def g4gps_write_emission_spectrum(

--- a/tests/test_scintillate.py
+++ b/tests/test_scintillate.py
@@ -1,0 +1,45 @@
+"""Test the attaching of all properties to Geant4 materials."""
+
+from __future__ import annotations
+
+import numpy as np
+import pint
+
+from legendoptics import lar, pen
+from legendoptics import scintillate as sc
+
+u = pint.get_application_registry()
+
+
+def test_scintillate_lar():
+    rng = np.random.default_rng()
+
+    params = sc.precompute_scintillation_params(
+        lar.lar_scintillation_params(),
+        lar.lar_lifetimes().as_tuple(),
+    )
+    part_e = sc.particle_to_index("electron")
+    part_ion = sc.particle_to_index("ion")
+
+    sc.scintillate_local(params, part_e, 10, rng)
+    sc.scintillate_local(params, part_ion, 10, rng)
+
+    x0 = np.array([0, 0, 0], dtype=np.float64)
+    x1 = np.array([0, 0, 1], dtype=np.float64)
+
+    sc.scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_e, -1, 1000, rng)
+    sc.scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_ion, -1, 1000, rng)
+
+
+def test_scintillate_pen():
+    rng = np.random.default_rng()
+
+    params = sc.precompute_scintillation_params(
+        pen.pen_scintillation_params(),
+        (pen.pen_scint_timeconstant(),),
+    )
+    part_e = sc.particle_to_index("electron")
+    part_ion = sc.particle_to_index("ion")
+
+    sc.scintillate_local(params, part_e, 10, rng)
+    sc.scintillate_local(params, part_ion, 10, rng)


### PR DESCRIPTION
1. Include the fano factor in the `ScintConfig` object, to bundle all properties relating to the amount of photons released
2. Povide a function `utils.scintillate(...)` to return an array of timestamps at which scintillation photon emission happens. This is strictly following Geant4's scintillation model

### Example usage:
```python3
import pint

import legendoptics.lar as lar
import legendoptics.utils as utils


u = pint.get_application_registry()

times = utils.scintillate(
    lar.lar_scintillation_params(),
    lar.lar_lifetimes().as_tuple(),
    "electron",
    1 * u.MeV
)
```
plotting a histogram of times gives the usual two-component exponential (x-axis is time in nanoseconds):
![image](https://github.com/legend-exp/legend-pygeom-optics/assets/10050780/7c5e04e7-3b1d-4a22-86b8-a8658d370827)

### Open discussion points
* Add a way to interact with scikit-hep/particle for conversion PDG id -> geant scintillation particle name (this is **not a simple lookup table**...)
* Geant also includes sampling a time and spatial offset calculation along the path segment (i.e. it assumes the energy deposition is uniform along the path, and not localized at its end). This is not yet implemented here, and would require a much more sophisticated output scheme (including start & end timestamps + coordinates for each segment with energy deposition)
