### PR TITLE
add option to scintillate without post_step point

### DIFF
--- a/src/legendoptics/scintillate.py
+++ b/src/legendoptics/scintillate.py
@@ -181,9 +181,9 @@ def scintillate_local(
 def scintillate(
     params: ComputedScintParams,
     x0_m: np.ndarray,
-    x1_m: np.ndarray,
-    v0_mpns: float,
-    v1_mpns: float,
+    x1_m: np.ndarray | None,
+    v0_mpns: float | None,
+    v1_mpns: float | None,
     t0_ns: float,
     particle: ParticleIndex,
     particle_charge: int,
@@ -194,6 +194,9 @@ def scintillate(
     """Generates a Poisson/Gauss-distributed number of photons according to the
     scintillation yield formula, as implemented in Geant4, along the line segment
     between x0 and x1.
+
+    In case x1 is not supplied the position along the step and the time offsets
+    are not considered. 
 
     Parameters
     ----------
@@ -230,19 +233,29 @@ def scintillate(
         params, particle, edep_keV, rng, emission_term_model
     )
     # emission position for each single photon.
-    if particle_charge != 0:
-        λ = rng.uniform(size=delta_t_scint.shape[0])
-    else:
-        λ = np.ones(shape=delta_t_scint.shape[0])
+    if (x1_m is not None):
+        if particle_charge != 0:
+            λ = rng.uniform(size=delta_t_scint.shape[0])
+        else:
+            λ = np.ones(shape=delta_t_scint.shape[0])
 
     x = np.empty((delta_t_scint.shape[0], 4))
     # spatial components along the line segment between x0 and x1.
-    x[:, 1] = x0_m[0] + λ * (x1_m[0] - x0_m[0])
-    x[:, 2] = x0_m[1] + λ * (x1_m[1] - x0_m[1])
-    x[:, 3] = x0_m[2] + λ * (x1_m[2] - x0_m[2])
-
+    if (x1_m is not None):
+        x[:, 1] = x0_m[0] + λ * (x1_m[0] - x0_m[0])
+        x[:, 2] = x0_m[1] + λ * (x1_m[1] - x0_m[1])
+        x[:, 3] = x0_m[2] + λ * (x1_m[2] - x0_m[2])
+    else:
+        x[:,1]=x0_m[0]
+        x[:,2]=x0_m[1]
+        x[:,3]=x0_m[2]
+    
     # time component along the velocity decrease between x0 and x1.
-    x[:, 0] = np.linalg.norm(x1_m - x0_m) / (v0_mpns + λ * (v1_mpns - v0_mpns) / 2)
+    if x1_m is not None:
+        x[:, 0] = np.linalg.norm(x1_m - x0_m) / (v0_mpns + λ * (v1_mpns - v0_mpns) / 2)
+    else:
+        x[:,0] = 0 
+
     # add the global time offset and the emission time offset.
     x[:, 0] += t0_ns + delta_t_scint
 

--- a/src/legendoptics/scintillate.py
+++ b/src/legendoptics/scintillate.py
@@ -196,7 +196,7 @@ def scintillate(
     between x0 and x1.
 
     In case x1 is not supplied the position along the step and the time offsets
-    are not considered. 
+    are not considered.
 
     Parameters
     ----------
@@ -233,7 +233,7 @@ def scintillate(
         params, particle, edep_keV, rng, emission_term_model
     )
     # emission position for each single photon.
-    if (x1_m is not None):
+    if x1_m is not None:
         if particle_charge != 0:
             λ = rng.uniform(size=delta_t_scint.shape[0])
         else:
@@ -241,20 +241,20 @@ def scintillate(
 
     x = np.empty((delta_t_scint.shape[0], 4))
     # spatial components along the line segment between x0 and x1.
-    if (x1_m is not None):
+    if x1_m is not None:
         x[:, 1] = x0_m[0] + λ * (x1_m[0] - x0_m[0])
         x[:, 2] = x0_m[1] + λ * (x1_m[1] - x0_m[1])
         x[:, 3] = x0_m[2] + λ * (x1_m[2] - x0_m[2])
     else:
-        x[:,1]=x0_m[0]
-        x[:,2]=x0_m[1]
-        x[:,3]=x0_m[2]
-    
+        x[:, 1] = x0_m[0]
+        x[:, 2] = x0_m[1]
+        x[:, 3] = x0_m[2]
+
     # time component along the velocity decrease between x0 and x1.
     if x1_m is not None:
         x[:, 0] = np.linalg.norm(x1_m - x0_m) / (v0_mpns + λ * (v1_mpns - v0_mpns) / 2)
     else:
-        x[:,0] = 0 
+        x[:, 0] = 0
 
     # add the global time offset and the emission time offset.
     x[:, 0] += t0_ns + delta_t_scint

--- a/tests/test_scintillate.py
+++ b/tests/test_scintillate.py
@@ -67,6 +67,24 @@ def test_scintillate_lar():
         scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_e, -1, 1000)
         scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_ion, -1, 1000)
 
+def test_scintillate_point_like():
+    params = sc.precompute_scintillation_params(
+        lar.lar_scintillation_params(),
+        lar.lar_lifetimes().as_tuple(),
+    )
+    part_e = sc.particle_to_index("electron")
+    part_ion = sc.particle_to_index("ion")
+
+    with numba_unwrap(sc, "scintillate_local") as scintillate_local:
+        scintillate_local(params, part_e, 10)
+        scintillate_local(params, part_ion, 10)
+
+    x0 = np.array([0, 0, 0], dtype=np.float64)
+    #x1 = np.array([0, 0, 1], dtype=np.float64)
+
+    with numba_unwrap(sc, "scintillate", ("scintillate_local",)) as scintillate:
+        scintillate(params, x0, None, None, None, 1234.5, part_e, -1, 1000)
+        scintillate(params, x0, None, None, None, 1234.5, part_ion, -1, 1000)
 
 def test_scintillate_pen():
     params = sc.precompute_scintillation_params(

--- a/tests/test_scintillate.py
+++ b/tests/test_scintillate.py
@@ -67,6 +67,7 @@ def test_scintillate_lar():
         scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_e, -1, 1000)
         scintillate(params, x0, x1, 0.1, 0.09, 1234.5, part_ion, -1, 1000)
 
+
 def test_scintillate_point_like():
     params = sc.precompute_scintillation_params(
         lar.lar_scintillation_params(),
@@ -80,11 +81,12 @@ def test_scintillate_point_like():
         scintillate_local(params, part_ion, 10)
 
     x0 = np.array([0, 0, 0], dtype=np.float64)
-    #x1 = np.array([0, 0, 1], dtype=np.float64)
+    # x1 = np.array([0, 0, 1], dtype=np.float64)
 
     with numba_unwrap(sc, "scintillate", ("scintillate_local",)) as scintillate:
         scintillate(params, x0, None, None, None, 1234.5, part_e, -1, 1000)
         scintillate(params, x0, None, None, None, 1234.5, part_ion, -1, 1000)
+
 
 def test_scintillate_pen():
     params = sc.precompute_scintillation_params(


### PR DESCRIPTION
Done in such a way to not change the API but is a bit ugly (i.e needs passing None).
I think nicer alternatives are:
- making some arguments accesible only by keyword
- a new function that just does the scintillation without the full step