### PR TITLE
Add two-component absorption length model

### DIFF
--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -253,6 +253,7 @@ def lar_abs_length(
 
 
     .. optics-plot:: {'call_x': True}
+    .. optics-plot:: {'call_x': True, 'standalone': True, 'extra_kwargs': {'method': 'legend200-llama-two-components'}}
     """
     if method == "default":
         λ = np.maximum(λ, 141 * u.nm)

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -248,12 +248,12 @@ def lar_abs_length(
 
     Notes
     -----
-    For ``mode="default``, the return value of this function has to be re-scaled with the
+    For ``mode="default"``, the return value of this function has to be re-scaled with the
     intended attenuation length at the VUV emission peak.
 
 
-    .. optics-plot:: {'call_x': True}
-    .. optics-plot:: {'call_x': True, 'standalone': True, 'extra_kwargs': {'method': 'legend200-llama-two-components'}}
+    .. optics-plot:: {'call_x': True, 'labels': ['default']}
+    .. optics-plot:: {'call_x': True, 'standalone': True, 'extra_kwargs': {'method': 'legend200-llama-two-components'}, 'labels': ['legend200-llama-two-components']}
     """
     if method == "default":
         λ = np.maximum(λ, 141 * u.nm)

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -241,7 +241,7 @@ def lar_abs_length(
     ----------
     λ
         Photon wavelength
-    abs_curve
+    method
         Choose the absorption curve model:
         - 'default': Standard exponential model
         - 'legend200-llama-two-components': Attenuation in the LEGEND-argon, as measured with LLAMA,

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -243,9 +243,11 @@ def lar_abs_length(
         Photon wavelength
     method
         Choose the absorption curve model:
+
         - 'default': Standard exponential model
         - 'legend200-llama-two-components': Attenuation in the LEGEND-argon, as measured with LLAMA,
-        can be described with a two-component absorption length model, see [Schwarz2024]_ (p. 137).
+          can be described with a two-component absorption length model, see [Schwarz2024]_ (p. 137).
+
 
     .. optics-plot:: {'call_x': True}
     """

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -227,7 +227,7 @@ def lar_rayleigh(
 @store.register_pluggable
 def lar_abs_length(
     λ: Quantity,
-    abs_curve: ArAbsCurveMethods = "default",
+    method: ArAbsCurveMethods = "default",
 ) -> Quantity:
     """Absorption length (not correctly scaled).
 
@@ -248,11 +248,11 @@ def lar_abs_length(
 
     .. optics-plot:: {'call_x': True}
     """
-    if abs_curve == "default":
+    if method == "default":
         λ = np.maximum(λ, 141 * u.nm)
         absl = 5.976e-12 * np.exp(0.223 * λ.to("nm").m) * u.cm
         return np.minimum(absl, 100000 * u.cm)  # avoid large numbers
-    if abs_curve == "legend200-llama-two-components":
+    if method == "legend200-llama-two-components":
         # Custom model with exponential transition through two control points
         # λ_peak = 126.8 nm: labs = 5.6 cm
         # λ_threshold = 133 nm: labs = 1000 cm
@@ -276,7 +276,7 @@ def lar_abs_length(
         )
 
         return absl_magnitude * u.cm
-    msg = f"unknown abs_curve: {abs_curve}"
+    msg = f"unknown method: {method}"
     raise ValueError(msg)
 
 

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -231,11 +231,9 @@ def lar_abs_length(
 ) -> Quantity:
     """Absorption length (not correctly scaled).
 
-    We don't know how the attenuation length actually varies with the wavelength, so here
-    we use a custom exponential function connecting the LAr Scintillation peak and the VIS
-    range just to avoid a step-like function. Still is a guess.
-    This function has to be re-scaled with the intended attenuation length at the VUV
-    emission peak.
+    We don't know how the attenuation length actually varies with the wavelength. With the
+    default model, we use a custom exponential function connecting the LAr Scintillation
+    peak and the VIS range just to avoid a step-like function. Still is a guess.
 
     Parameters
     ----------
@@ -244,9 +242,14 @@ def lar_abs_length(
     method
         Choose the absorption curve model:
 
-        - 'default': Standard exponential model
-        - 'legend200-llama-two-components': Attenuation in the LEGEND-argon, as measured with LLAMA,
+        - ``default``: Standard exponential model
+        - ``legend200-llama-two-components``: Attenuation in the LEGEND-argon, as measured with LLAMA,
           can be described with a two-component absorption length model, see [Schwarz2024]_ (p. 137).
+
+    Notes
+    -----
+    For ``mode="default``, the return value of this function has to be re-scaled with the
+    intended attenuation length at the VUV emission peak.
 
 
     .. optics-plot:: {'call_x': True}

--- a/src/pygeomoptics/lar.py
+++ b/src/pygeomoptics/lar.py
@@ -244,7 +244,8 @@ def lar_abs_length(
     abs_curve
         Choose the absorption curve model:
         - 'default': Standard exponential model
-        - 'legend200-llama-two-components': Custom two-point exponential transition model
+        - 'legend200-llama-two-components': Attenuation in the LEGEND-argon, as measured with LLAMA,
+        can be described with a two-component absorption length model, see [Schwarz2024]_ (p. 137).
 
     .. optics-plot:: {'call_x': True}
     """

--- a/src/pygeomoptics/plot.py
+++ b/src/pygeomoptics/plot.py
@@ -149,11 +149,13 @@ def plot_callable(
 
         po = {"marker": ".", "markersize": 2, "linewidth": 0.5}
         if "labels" in options:
+            if len(options["labels"]) == 1:
+                raise ValueError(options["labels"])
             po["label"] = options["labels"][i]
 
         ax.plot(x, y, **(po | plotoptions))
 
-    if len(ys) > 1 and "labels" in options:
+    if "labels" in options:
         ax.legend()
 
     # adjust plotting options

--- a/src/pygeomoptics/plot.py
+++ b/src/pygeomoptics/plot.py
@@ -149,8 +149,6 @@ def plot_callable(
 
         po = {"marker": ".", "markersize": 2, "linewidth": 0.5}
         if "labels" in options:
-            if len(options["labels"]) == 1:
-                raise ValueError(options["labels"])
             po["label"] = options["labels"][i]
 
         ax.plot(x, y, **(po | plotoptions))

--- a/src/pygeomoptics/plot.py
+++ b/src/pygeomoptics/plot.py
@@ -99,6 +99,8 @@ def plot_callable(
         ret_offset
             use the argument numbered by this (default: 0) as the first argument that will
             be treated as an x or y vector.
+        extra_kwargs
+            add more kwargs to the ``obj()`` call.
     """
     # init plot
     has_ax = ax is not None
@@ -110,18 +112,19 @@ def plot_callable(
     plotoptions = plotoptions if plotoptions is not None else {}
 
     ret_offset = options.get("ret_offset", 0)
+    extra_kwargs = options.get("extra_kwargs", {})
     if "call_x" in options:
         # special case for LAr properties
         lim = [112 * u.nm, 650 * u.nm]
         if "xlim" in options:
             lim = [xl * u.nm for xl in options["xlim"]]
         x = np.linspace(*lim, num=200)
-        ys = obj(x)
+        ys = obj(x, **extra_kwargs)
         ys = ys[ret_offset:]
         # wrap the result in a tuple, if needed
         ys = ys if isinstance(ys, tuple) else (ys,)
     else:
-        data = obj()
+        data = obj(**extra_kwargs)
         x = data[ret_offset]
         # ys holds one or more
         ys = data[ret_offset + 1 :]

--- a/tests/test_lar.py
+++ b/tests/test_lar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pint
 import pytest
+import numpy as np
 
 from pygeomoptics import lar
 
@@ -15,3 +16,19 @@ def test_dielectric_constant():
     assert lar.lar_dielectric_constant_cern2020(128 * u.nm) == pytest.approx(
         1.846, rel=1e-3
     )
+
+def test_two_component_absorption_length():
+    
+    _, peak_absl, λ_full, _, abslength, _ = lar.lar_calculate_attenuation(
+        88.8 * u.K,
+        lar_dielectric_method="cern2020",
+        absorption_enabled_or_length="legend200-llama-two-components",
+    )
+    
+    assert peak_absl.m == pytest.approx(
+        5.6, rel=1e-3
+    )
+    
+    assert abslength[λ_full==np.max(λ_full)][0].m == pytest.approx(
+            1000, rel=1e-3
+        )

--- a/tests/test_lar.py
+++ b/tests/test_lar.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
 import pint
 import pytest
-import numpy as np
 
 from pygeomoptics import lar
 
@@ -17,18 +17,14 @@ def test_dielectric_constant():
         1.846, rel=1e-3
     )
 
+
 def test_two_component_absorption_length():
-    
     _, peak_absl, λ_full, _, abslength, _ = lar.lar_calculate_attenuation(
         88.8 * u.K,
         lar_dielectric_method="cern2020",
         absorption_enabled_or_length="legend200-llama-two-components",
     )
-    
-    assert peak_absl.m == pytest.approx(
-        5.6, rel=1e-3
-    )
-    
-    assert abslength[λ_full==np.max(λ_full)][0].m == pytest.approx(
-            1000, rel=1e-3
-        )
+
+    assert peak_absl.m == pytest.approx(5.6, rel=1e-3)
+
+    assert abslength[λ_full == np.max(λ_full)][0].m == pytest.approx(1000, rel=1e-3)

--- a/tests/test_pyg4.py
+++ b/tests/test_pyg4.py
@@ -59,6 +59,13 @@ def test_pyg4_attach_lar() -> None:
         mat, reg, 90 * u.K, rayleigh_enabled_or_length=False
     )
     assert "RAYLEIGH" not in mat.properties
+    reg, mat = _create_dummy_mat()
+    pygeomoptics.lar.pyg4_lar_attach_attenuation(
+        mat,
+        reg,
+        90 * u.K,
+        absorption_enabled_or_length="legend200-llama-two-components",
+    )
 
 
 def test_pyg4_attach_tpb() -> None:


### PR DESCRIPTION
In @schwarzmario PhD thesis chapter 8.4.3 an absorption spectrum with two absorption lengths is described, that describes LEGEND-200 LLAMA data. This is the implementation of this model. See below absorption and attenuation curves.
<img width="580" height="455" alt="image" src="https://github.com/user-attachments/assets/f93760e1-4125-4cc7-8fb5-e69122ca81f6" />
<img width="580" height="455" alt="image" src="https://github.com/user-attachments/assets/4d12a0c3-3f6d-4af5-9df6-d1425c3bacf2" />
