### PR TITLE
drop support for python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     pre_build:
       - rm -rf docs/source/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "importlib_resources",
     "numba",


### PR DESCRIPTION
not technically necessray right now, but at some point we should do it (also reboost/revertex/remage already require >=3.11...)